### PR TITLE
Big http client refactor. Add integration tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,8 +105,6 @@ jobs:
           name: Coverage
           command: |
             poetry run pytest --cov=pycaprio --cov-branch --cov-fail-under=90 --cov-report=xml --cov-report=html tests/unit_tests
-      - codecov/upload:
-          flags: unittest
 
   release-on-tag:
     docker:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,27 +6,30 @@ Here are a few guidelines and "How to"s that will help you with the contribution
 
 ## Before contributing...
 
-Take a moment to search through `pycaprio`'s [issues](https://github.com/JavierLuna/pycaprio/issues) to check whether the
-bug you are experiencing or the feature you would want implemented are being discussed.
+Take a moment to search through `pycaprio`'s [issues](https://github.com/JavierLuna/pycaprio/issues) to check whether
+the bug you are experiencing or the feature you would want implemented are being discussed.
 
-Please check out the [Code of Conduct](https://github.com/JavierLuna/pycaprio/blob/main/CODE_OF_CONDUCT.md) for this repository.
-This Code of Conduct is adapted from the Contributor Covenant, version 2.0, available at http://contributor-covenant.org/version/2/0/code_of_conduct/
+Please check out the [Code of Conduct](https://github.com/JavierLuna/pycaprio/blob/main/CODE_OF_CONDUCT.md) for this
+repository. This Code of Conduct is adapted from the Contributor Covenant, version 2.0, available
+at http://contributor-covenant.org/version/2/0/code_of_conduct/
 
-Lastly, please remember that I am a human as well. I will get back to you whenever I have time, be patient if I don't reply in a couple of days or three.
+Lastly, please remember that I am a human as well. I will get back to you whenever I have time, be patient if I don't
+reply in a couple of days or three.
 
 ## Pull requests
 
-Once you are done with your contribution (don't forget about tests and documentation!), please open a pull request against `main`.
+Once you are done with your contribution (don't forget about tests and documentation!), please open a pull request
+against `main`.
 
-Please, read ["How to write a Git commit message"](https://chris.beams.io/posts/git-commit/) before writing your commit messages, I will expect
-the messages to follow that advise.
+Please, read ["How to write a Git commit message"](https://chris.beams.io/posts/git-commit/) before writing your commit
+messages, I will expect the messages to follow that advise.
 
-Include a reference to the open related issue and wait for me to review the changes and for the CI to run the tests/linting.
+Include a reference to the open related issue and wait for me to review the changes and for the CI to run the
+tests/linting.
 
 Further code discussion should go in the Pull Request, while the rest should go into the issue.
 
 Once the PR is approved, I'll merge the PR and schedule it for a next release.
-
 
 ## How to work on Pycaprio
 
@@ -36,13 +39,15 @@ Fork the repository into your account and clone it in your work station.
 
 To work on `pycaprio`, you will need Python 3.6+ and [Poetry](https://github.com/python-poetry/poetry) installed.
 
-There's a [Makefile](https://github.com/JavierLuna/pycaprio/blob/main/Makefile) to make your dev life easier, but if you cannot run `make` in your system, just open the file and do the same commands.
-
+There's a [Makefile](https://github.com/JavierLuna/pycaprio/blob/main/Makefile) to make your dev life easier, but if you
+cannot run `make` in your system, just open the file and do the same commands.
 
 ### Installing the dependencies
 
 Now, you have two options (this is just up to personal preference):
-1. Create and manage your own virtual env, activate it and develop inside it. Read [this](https://realpython.com/python-virtual-environments-a-primer/).
+
+1. Create and manage your own virtual env, activate it and develop inside it.
+   Read [this](https://realpython.com/python-virtual-environments-a-primer/).
 2. Let Poetry handle virtual environments for you. Then just use the `make`.
 
 I personally prefer option **1** but feel free to use whichever is more comfortable to you.
@@ -53,13 +58,28 @@ At this point, you should have everything ready to start developing, but what is
 
 ### Run tests and the linter
 
-To run the tests: `make tests`
+This project has both unit tests and integration tests. Unit tests are fine to run in isolation by
+just `make unit-tests`.
+
+For the integration tests, you will need a reachable INCEpTION instance that has the remote API enabled. Needlessly to
+say, **DO NOT USE A PROD INSTANCE FOR THIS, USE A DISPOSABLE ONE**. By default, the integs will
+target `http://localhost:8080`, although you can override that value via `TEST_INCEPTION_ENDPOINT` env variable.
+
+You will need to then create an user there and enable `REMOTE_API` permissions.
+
+The username and password should be `test-remote`, although you can override those values by using the
+`TEST_USERNAME` and `TEST_PASSWORD` env variables.
+
+To run the integration tests use: `make integ-tests`
+
+To run all tests use: `make tests`
 
 To run the linter: `make lint`
 
 ### Documentation
 
-There's a [docs](https://github.com/JavierLuna/pycaprio/tree/main/docs) directory that contains all `pycaprio`'s documentation.
+There's a [docs](https://github.com/JavierLuna/pycaprio/tree/main/docs) directory that contains all `pycaprio`'s
+documentation.
 
 You may add/change the files there if your contribution requires so.
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@ dependencies:
 unit-tests:
 	poetry run py.test --cov=pycaprio --cov-branch --cov-fail-under=90 tests/unit_tests
 
-tests: unit-tests
+integ-tests:
+	poetry run py.test --cov=pycaprio --cov-branch --cov-fail-under=90 tests/integ_tests
+
+tests: unit-tests integ-tests
 
 coverage:
 	poetry run py.test --cov=pycaprio --cov-branch --cov-fail-under=90 --cov-report=html tests

--- a/README.md
+++ b/README.md
@@ -26,23 +26,5 @@ pycaprio_client.api.create_project("Project name", "creator-username")
 
 Check the [documentation](https://pycaprio.readthedocs.io) if you want to know more.
 
-## Current state of Pycaprio
-Hi! I'm Javier and I am the maintainer of `pycaprio`.
-I developed this library when I was working at [Savanamed](https://github.com/Savanamed) where I pushed for it to be open sourced
-so the research community could also use INCEpTION's API a bit easier.
-
-While I don't work for the company anymore, I'd like to continue maintaining this project.
-Pycaprio is MIT licensed, so I created this fork and continue my work, but the `pycaprio` PyPi package is still owned by Savana.
-
-Now, I don't want to just create a "pycaprio2" and tell you to update, so I've asked Savanamed for an ownership transfer of that package.
-That will mean you can use the project as always and I can keep on maintaining it. That's a fair deal!
-
-However, as the spanish proverb says, "Las cosas de palacio van despacio"/"Things at the palace go slowly" so
-expect a bit of delay on that ownership transfer. I'll keep you posted.
-
-Thank you for using the project!
-
-Javier
-
 ## License
 Pycaprio is under the MIT license. Check it out [here](https://opensource.org/licenses/MIT)

--- a/pycaprio/core/clients/exceptions.py
+++ b/pycaprio/core/clients/exceptions.py
@@ -1,7 +1,0 @@
-import requests
-
-
-class RetryableException(Exception):
-    def __init__(self, bad_response: requests.Response):
-        super().__init__()
-        self.bad_response = bad_response

--- a/pycaprio/core/exceptions.py
+++ b/pycaprio/core/exceptions.py
@@ -14,5 +14,6 @@ class InceptionBadResponse(Exception):
     """
 
     def __init__(self, bad_response: requests.Response):
-        super().__init__()
+        super().__init__(f"HTTP {bad_response.status_code}: {bad_response.text}")
         self.bad_response = bad_response
+        self.status_code = bad_response.status_code

--- a/pycaprio/core/interfaces/client.py
+++ b/pycaprio/core/interfaces/client.py
@@ -6,7 +6,6 @@ from urllib.parse import urlparse
 import requests
 
 from pycaprio.core.interfaces.types import authentication_type
-from pycaprio.core.interfaces.types import status_list_type
 
 
 class BaseInceptionClient(metaclass=ABCMeta):
@@ -34,55 +33,41 @@ class BaseInceptionClient(metaclass=ABCMeta):
         return f"{self.inception_host}{self.INCEPTION_API_PATH}{relative_url}"
 
     @abstractmethod
-    def get(self, url: str, data: Optional[dict],
-            allowed_statuses: Optional[status_list_type] = None) -> requests.Response:
+    def get(self, url: str, data: Optional[dict]) -> requests.Response:
         """
         Issues an authenticated GET request to Inception
         :param url: relative url to make request
         :param data: Parameters to include in the request
-        :param allowed_statuses: Tuple of allowed statuses.
-        If the response's status code is not in the list, a BadInceptionResponse exception will be risen.
-        None allows all status codes
         :return: Response
         """
         pass  # pragma: no cover
 
     @abstractmethod
-    def post(self, url: str, json: dict, files: dict,
-             allowed_statuses: Optional[status_list_type] = None) -> requests.Response:
+    def post(self, url: str, json: dict, files: dict) -> requests.Response:
         """
         Issues an authenticated POST request to Inception
         :param url: relative url to make request
         :param json: JSON body
         :param files: Files to be uploaded.
-        :param allowed_statuses: Tuple of allowed statuses.
-        If the response's status code is not in the list, a BadInceptionResponse exception will be risen.
-        None allows all status codes
         :return: Response
         """
         pass  # pragma: no cover
 
     @abstractmethod
-    def delete(self, url: str, allowed_statuses: Optional[status_list_type] = None) -> requests.Response:
+    def delete(self, url: str) -> requests.Response:
         """
         Issues an authenticated DELETE request to Inception
         :param url: relative url to make request
-        :param allowed_statuses: Tuple of allowed statuses.
-        If the response's status code is not in the list, a BadInceptionResponse exception will be risen.
-        None allows all status codes
         :return: Response
         """
         pass  # pragma: no cover
 
     @abstractmethod
-    def request(self, method: str, url: str, allowed_statuses: Optional[status_list_type],
+    def request(self, method: str, url: str,
                 **kwargs) -> requests.Response:
         """
         Issues an authenticated request to Inception
         :param url: relative url to make request
-        :param allowed_statuses: Tuple of allowed statuses.
-        If the response's status code is not in the list, a BadInceptionResponse exception will be risen.
-        None allows all status codes
         :return: Response
         """
         pass  # pragma: no cover

--- a/pycaprio/core/interfaces/types.py
+++ b/pycaprio/core/interfaces/types.py
@@ -1,4 +1,3 @@
 from typing import Tuple
 
 authentication_type = Tuple[str, str]
-status_list_type = Tuple[int, ...]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.6"
 requests = "*"
-tenacity = "^5.1"
+requests-toolbelt = "^0.9.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/tests/integ_tests/conftest.py
+++ b/tests/integ_tests/conftest.py
@@ -1,0 +1,59 @@
+import random
+import io
+import os
+
+import pytest
+import requests
+
+from pycaprio import Pycaprio
+
+TEST_INCEPTION_ENDPOINT = os.getenv("TEST_INCEPTION_ENDPOINT", default="http://localhost:8080")
+TEST_USERNAME = os.getenv("TEST_USERNAME", default='test-remote')
+TEST_PASSWORD = os.getenv("TEST_PASSWORD", default='test-remote')
+TEST_PROJECT_PREFIX = os.getenv("TEST_PROJECT_PREFIX", default='testpycap')
+TEST_CONTENT = "this is a whatever whatever test string"
+
+
+def gen_test_name():
+    return f"{TEST_PROJECT_PREFIX}{random.randint(0, 1000000000)}"
+
+
+def is_inception_alive():
+    return requests.get(TEST_INCEPTION_ENDPOINT).status_code == 200
+
+
+def is_api_accessible():
+    return requests.get(f"{TEST_INCEPTION_ENDPOINT}/swagger-ui/index.html").status_code == 200
+
+
+@pytest.fixture(scope='session', autouse=True)
+def pycaprio():
+    if not is_inception_alive():
+        raise Exception(f"Could not reach out INCEpTION on endpoint '{TEST_INCEPTION_ENDPOINT}")
+
+    if not is_api_accessible():
+        raise Exception("Cannot reach API endpoint, did you enable it?")
+
+    client = Pycaprio(TEST_INCEPTION_ENDPOINT, authentication=(TEST_USERNAME, TEST_PASSWORD))
+    yield client
+    [client.api.delete_project(p) for p in client.api.projects() if p.project_name.startswith(TEST_PROJECT_PREFIX)]
+
+
+@pytest.fixture
+def test_name():
+    return gen_test_name()
+
+
+@pytest.fixture(scope='session', autouse=True)
+def test_project(pycaprio):
+    return pycaprio.api.create_project(gen_test_name())
+
+
+@pytest.fixture
+def test_io():
+    return io.StringIO(TEST_CONTENT)
+
+
+@pytest.fixture
+def test_document(pycaprio, test_project):
+    return pycaprio.api.create_document(test_project, gen_test_name(), io.StringIO(TEST_CONTENT))

--- a/tests/integ_tests/test_annotation.py
+++ b/tests/integ_tests/test_annotation.py
@@ -1,0 +1,36 @@
+from pycaprio.core.mappings import AnnotationState
+from pycaprio.core.objects import Annotation
+from tests.integ_tests.conftest import TEST_USERNAME, TEST_CONTENT
+
+
+def test_list_annotation(pycaprio, test_project, test_document, test_io):
+    pycaprio.api.create_annotation(test_project, test_document, TEST_USERNAME, test_io)
+    annotations = pycaprio.api.annotations(test_project, test_document)
+    assert annotations
+    assert all(isinstance(a, Annotation) for a in annotations)
+
+
+def test_create_annotation(pycaprio, test_project, test_document, test_io):
+    annotation = pycaprio.api.create_annotation(test_project, test_document, TEST_USERNAME, test_io)
+    assert annotation in pycaprio.api.annotations(test_project, test_document)
+
+
+def test_detail_annotation(pycaprio, test_project, test_document, test_io):
+    annotation = pycaprio.api.create_annotation(test_project, test_document, TEST_USERNAME, test_io)
+    assert TEST_CONTENT == pycaprio.api.annotation(test_project, test_document, annotation.user_name).decode('utf-8')
+
+
+def test_delete_annotation(pycaprio, test_project, test_document, test_io):
+    annotation = pycaprio.api.create_annotation(test_project, test_document, TEST_USERNAME, test_io)
+    pycaprio.api.delete_annotation(test_project, test_document, annotation.user_name)
+    assert annotation not in pycaprio.api.annotations(test_project, test_document)
+
+
+def test_update_annotation_state(pycaprio, test_project, test_document, test_io):
+    initial_annotation = pycaprio.api.create_annotation(test_project, test_document, TEST_USERNAME, test_io)
+    pycaprio.api.update_annotation_state(test_project, test_document, initial_annotation.user_name,
+                                         AnnotationState.COMPLETE)
+    updated_annotation = \
+        [a for a in pycaprio.api.annotations(test_project, test_document) if
+         a.user_name == initial_annotation.user_name][0]
+    assert updated_annotation.annotation_state == AnnotationState.COMPLETE

--- a/tests/integ_tests/test_document.py
+++ b/tests/integ_tests/test_document.py
@@ -1,0 +1,25 @@
+from pycaprio.core.objects import Document
+from tests.integ_tests.conftest import TEST_CONTENT
+
+
+def test_create_document(pycaprio, test_project, test_name, test_io):
+    document = pycaprio.api.create_document(test_project, test_name, test_io)
+    assert document in pycaprio.api.documents(test_project)
+
+
+def test_list_documents(pycaprio, test_project, test_name, test_io):
+    pycaprio.api.create_document(test_project, test_name, test_io)
+    documents = pycaprio.api.documents(test_project)
+    assert documents
+    assert all(isinstance(d, Document) for d in documents)
+
+
+def test_detail_document_gives_content(pycaprio, test_project, test_name, test_io):
+    document = pycaprio.api.create_document(test_project, test_name, test_io)
+    assert pycaprio.api.document(test_project, document).decode('utf-8') == TEST_CONTENT
+
+
+def test_delete_document(pycaprio, test_project, test_name, test_io):
+    document = pycaprio.api.create_document(test_project, test_name, test_io)
+    pycaprio.api.delete_document(test_project, document)
+    assert document not in pycaprio.api.documents(test_project)

--- a/tests/integ_tests/test_project.py
+++ b/tests/integ_tests/test_project.py
@@ -1,0 +1,27 @@
+from pycaprio.core.objects import Project
+
+
+def test_list_projects(pycaprio, test_name):
+    pycaprio.api.create_project(test_name)
+    projects = pycaprio.api.projects()
+    assert projects
+    assert all(isinstance(project, Project) for project in projects)
+
+
+def test_create_project(pycaprio, test_name):
+    initial_projects = list(pycaprio.api.projects())
+    project = pycaprio.api.create_project(test_name)
+    assert isinstance(project, Project)
+    assert project not in initial_projects
+    assert project in list(pycaprio.api.projects())
+
+
+def test_delete_project(pycaprio, test_name):
+    project = pycaprio.api.create_project(test_name)
+    pycaprio.api.delete_project(project)
+    assert project not in pycaprio.api.projects()
+
+
+def test_detail_project(pycaprio, test_name):
+    project = pycaprio.api.create_project(test_name)
+    assert project == pycaprio.api.project(project)

--- a/tests/unit_tests/core/clients/test_retryable_client.py
+++ b/tests/unit_tests/core/clients/test_retryable_client.py
@@ -2,13 +2,10 @@ from unittest.mock import Mock
 from urllib.parse import urlparse
 
 import pytest
-from tenacity import RetryError
 
-from pycaprio.core.clients.exceptions import RetryableException
 from pycaprio.core.clients.retryable_client import RetryableInceptionClient
 from pycaprio.core.exceptions import InceptionBadResponse
 from pycaprio.core.interfaces.types import authentication_type
-from pycaprio.core.interfaces.types import status_list_type
 
 
 @pytest.mark.parametrize("host, test_relative_url", [('http://host/', '/test-relative'),
@@ -63,88 +60,10 @@ def test_client_get_post_delete_calls_request_function_with_same_url(mock_reques
 
 
 @pytest.mark.parametrize("http_verb", ['get', 'post', 'delete'])
-def test_client_get_post_delete_calls_request_function_with_same_allowed_status(mock_request_function: Mock,
-                                                                                client: RetryableInceptionClient,
-                                                                                http_verb: str):
-    test_url = "test-url"
-    test_allowed_statuses = [1, 2, 3]
-    getattr(RetryableInceptionClient, http_verb)(client, test_url, allowed_statuses=test_allowed_statuses)
-    assert mock_request_function.call_args[0][2] == test_allowed_statuses
-
-
-def test_client_post_form_data_translates_into_files_none(mock_request_function: Mock,
-                                                          client: RetryableInceptionClient):
-    test_url = "test-url"
-    form_data = {'test': 'test-value'}
-    client.post(test_url, form_data=form_data, files=None)
-    assert mock_request_function.call_args[1]['files'] == {'test': (None, form_data['test'])}
-
-
-def test_client_post_form_data_translates_into_files_empty_dict(mock_request_function: Mock,
-                                                                client: RetryableInceptionClient):
-    test_url = "test-url"
-    form_data = {'test': 'test-value'}
-    client.post(test_url, form_data=form_data, files={})
-    assert mock_request_function.call_args[1]['files'] == {'test': (None, form_data['test'])}
-
-
-def test_client_post_form_data_translates_into_files_not_overwrite(mock_request_function: Mock,
-                                                                   client: RetryableInceptionClient):
-    test_url = "test-url"
-    form_data = {'test': 'test-value'}
-    files = {'example': (None, None)}
-    client.post(test_url, form_data=form_data, files=files)
-    assert mock_request_function.call_args[1]['files'] == {'test': (None, form_data['test']),
-                                                           'example': files['example']}
-
-
-@pytest.mark.parametrize("http_verb", ['get', 'post', 'delete'])
 def test_client_request_returns_inception_bad_request_if_already_retried(mocker, client: RetryableInceptionClient,
                                                                          http_verb):
-    retry_error = RetryError(Mock())
+    retry_error = InceptionBadResponse(Mock())
     mocker.patch('pycaprio.core.clients.retryable_client.RetryableInceptionClient._request', side_effect=retry_error)
+    mocker.patch('time.sleep')
     with pytest.raises(InceptionBadResponse):
-        client.request(http_verb, "", (1, 2, 3))
-
-
-def do_mocked_request(mocker, client: RetryableInceptionClient, allowed_statuses: status_list_type,
-                      response_status_code: int,
-                      *args, **kwargs):
-    mocker.patch('tenacity.BaseRetrying.wraps', return_value=lambda f: f)
-    client.session = Mock()
-    client.session.request = Mock(return_value=type('MockedResponse', (), {'status_code': response_status_code}))
-    response = client._request.__wrapped__(client, "test-verb", "test-url", allowed_statuses=allowed_statuses, *args,
-                                           **kwargs)
-    return response
-
-
-def test_status_code_in_no_retry_list_not_allowed_raise_exception(mocker, client: RetryableInceptionClient):
-    response_status_code = 404
-    client.NO_RETRY_STATUSES = [response_status_code]
-    with pytest.raises(InceptionBadResponse):
-        do_mocked_request(mocker, client, (response_status_code + 1,), response_status_code)
-
-
-def test_status_code_in_no_retry_list_but_allowed_no_raise_exception(mocker, client: RetryableInceptionClient):
-    response_status_code = 404
-    client.NO_RETRY_STATUSES = [response_status_code]
-    try:
-        do_mocked_request(mocker, client, (response_status_code,), response_status_code)
-    except RetryableException:
-        pytest.fail()
-
-
-def test_status_not_allowed_and_retryable_raise_exception(mocker, client: RetryableInceptionClient):
-    response_status_code = 500
-    client.NO_RETRY_STATUSES = [response_status_code + 1]
-    with pytest.raises(RetryableException):
-        do_mocked_request(mocker, client, (response_status_code + 2,), response_status_code)
-
-
-def test_status_allowed_and_retryable_no_raise_exception(mocker, client: RetryableInceptionClient):
-    response_status_code = 500
-    client.NO_RETRY_STATUSES = [response_status_code + 1]
-    try:
-        do_mocked_request(mocker, client, (response_status_code,), response_status_code)
-    except RetryableException:
-        pytest.fail()
+        client.request(http_verb, "")


### PR DESCRIPTION
Fixes #5

HTTP client changes:

- Only GET operations are now retried
- Change retriable status codes to be more forgiving
- Fix how multipart form data was uploaded. There was an issue where the
  boundries were wrongly calculated and INCEpTION would freak out.
- Improve messages of API errors

Other changes:

- Add integration tests. They require an accessible **NON PROD**
  INCEpTION instance.
- Updated CONTRIBUTING to include instructions to run integs
- Remove old disclaimer from README. That situation is solved.
- Remove codecov orb that was making the CI fail. I'll fix it in another
  PR.